### PR TITLE
Added cropping in image2labels to remove paddings added by prepare_input

### DIFF
--- a/relabel/relabeling.py
+++ b/relabel/relabeling.py
@@ -216,6 +216,12 @@ def image2labels(img: da.Array, seg_fn: Callable,
         ndim=ndim
     )
 
+    # Remove the pad added with prepare_input
+    labels = labels[
+        tuple([slice(None)] * (labels.ndim - ndim)
+              + [slice(0, s) for s in img.shape[-ndim:]])
+    ]
+
     return labels
 
 

--- a/tests/test_relabeling.py
+++ b/tests/test_relabeling.py
@@ -206,6 +206,11 @@ def test_image2labels(input_output):
         segmentation_fn_kwargs=segmentation_fun_kwargs
     )
 
+    labels_expected = labels_expected[
+        tuple([slice(None)] * (labels_expected.ndim - ndim)
+              + [slice(0, s) for s in input_img.shape[-ndim:]])
+    ]
+
     labels_expected = labels_expected.compute()
     labels_output = labels_output.compute()
 


### PR DESCRIPTION
The pre-process function `prepare_input` pads the image when it contains chunks of smaller size than the input's chunk size. These usually are located at the tailing edges of the image. 

Therefore the output labels image has different spatial shape than the input image. This can be solved by removing the corresponding padded pixels from the labels output.
